### PR TITLE
Extended exrefs to resolve for System.Int types

### DIFF
--- a/sphinx_csharp/extrefs_data.py
+++ b/sphinx_csharp/extrefs_data.py
@@ -52,7 +52,8 @@ class ExternalRefsData:
     """
     external_type_map = {
         'msdn': {
-            'System': ['Tuple', 'IDisposable', 'ICloneable', 'IComparable', 'Func', 'Action'],
+            'System': ['Tuple', 'IDisposable', 'ICloneable', 'IComparable', 'Func', 'Action',
+                       'Int16', 'Int32', 'Int64', 'Int128', 'UInt16', 'UInt32', 'UInt64', 'UInt128'],
             'System.Collections': ['IEnumerator'],
             'System.Collections.Generic': ['List', 'Dictionary', 'IList', 'IDictionary', 'ISet', 'IEnumerable'],
             'System.IO': ['FileFormatException'],


### PR DESCRIPTION
This resolves errors similar to

`WARNING: Failed to find xref for: UInt64, no objects found that end like this, searched in object types: ['class', 'struct', 'interface', 'enum']`